### PR TITLE
Add CMake file to root to build all CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.12.2)
+
+project(opencog)
+
+find_package(CogUtil 2.0.1 CONFIG REQUIRED)
+find_package(AtomSpace 5.0.3 CONFIG REQUIRED)
+find_package(AttentionBank 1.0.0 CONFIG)
+find_package(URE 1.0.0 CONFIG)
+find_package(PLN CONFIG)
+find_package(LGAtomese 1.0.0 CONFIG)
+find_package(Boost 1.46 COMPONENTS system REQUIRED)
+find_package(Cxxtest)
+include(OpenCogFindGuile)
+include(OpenCogFindPython)
+find_package(VALGRIND)
+find_package(Doxygen)


### PR DESCRIPTION
Add a CMakeLists.txt file to the root directory to allow the build.yml action to build all CMake files in all subdirectories from an orchestrated workflow.

* Set the minimum required CMake version to 2.8.12.2
* Define the project name as `opencog`
* Add the `CogUtil` package with version 2.0.1
* Add the `AtomSpace` package with version 5.0.3
* Add the `AttentionBank` package with version 1.0.0
* Add the `URE` package with version 1.0.0
* Add the `PLN` package
* Add the `LGAtomese` package with version 1.0.0
* Add the `Boost` package with version 1.46 and component `system`
* Add the `Cxxtest` package
* Include `OpenCogFindGuile`
* Include `OpenCogFindPython`
* Add the `Valgrind` package
* Add the `Doxygen` package

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EchoCog/opencog-central/pull/1?shareId=2ce878dc-0130-4b1e-9a5c-3101cf21c32f).