### PR TITLE
Consolidate all atomspace folders under orch-atomspace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,10 @@
             ]
         }
     },
-    "postCreateCommand": "pip3 install -r requirements.txt && cargo install hyperon"
+    "postCreateCommand": "pip3 install -r requirements.txt && cargo install hyperon",
+    "tasks": {
+      "build": "pip3 install -r requirements.txt && cargo install hyperon"
+    }
 }
 
 

--- a/.github/workflows/ci-org-v2.yml
+++ b/.github/workflows/ci-org-v2.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /ws/ccache
-          key: ccache-atomspace-${{ runner.os }}-${{ hashFiles('atomspace/**') }}
+          key: ccache-atomspace-${{ runner.os }}-${{ hashFiles('orch-atomspace/atomspace/**') }}
           restore-keys: |
             ccache-atomspace-
 
@@ -135,41 +135,41 @@ jobs:
 
       - name: Configure CMake for AtomSpace
         run: |
-          mkdir -p atomspace/build
-          cd atomspace/build
+          mkdir -p orch-atomspace/atomspace/build
+          cd orch-atomspace/atomspace/build
           cmake -DCMAKE_PREFIX_PATH=/usr/local ..  # Ensure CMake can find CogUtil
 
       - name: Build AtomSpace
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make
 
       - name: Install AtomSpace
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           sudo make install
           sudo ldconfig
 
       - name: Build AtomSpace Tests
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make tests
 
       - name: Run AtomSpace Tests
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make check ARGS="$MAKEFLAGS"
 
       - name: Print AtomSpace Test Log
         if: always()
         run: |
-          cat atomspace/build/tests/Testing/Temporary/LastTest.log || echo "Test log not found."
+          cat orch-atomspace/atomspace/build/tests/Testing/Temporary/LastTest.log || echo "Test log not found."
 
       - name: Upload AtomSpace Artifact
         uses: actions/upload-artifact@v4
         with:
           name: atomspace
-          path: atomspace/build/
+          path: orch-atomspace/atomspace/build/
 
   cogserver:
     name: CogServer Job

--- a/.github/workflows/ci-org-v3.yml
+++ b/.github/workflows/ci-org-v3.yml
@@ -74,8 +74,8 @@ jobs:
       # 6. Build and Install AtomSpace
       - name: Build and Install AtomSpace
         run: |
-          mkdir -p atomspace/build
-          cd atomspace/build
+          mkdir -p orch-atomspace/atomspace/build
+          cd orch-atomspace/atomspace/build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/local ..
           make
           sudo make install
@@ -84,7 +84,7 @@ jobs:
       # 7. Run AtomSpace Tests
       - name: Run AtomSpace Tests
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make tests
           make check ARGS="$MAKEFLAGS"
 
@@ -92,13 +92,13 @@ jobs:
       - name: Print AtomSpace Test Log
         if: always()
         run: |
-          cat atomspace/build/tests/Testing/Temporary/LastTest.log || echo "Test log not found."
+          cat orch-atomspace/atomspace/build/tests/Testing/Temporary/LastTest.log || echo "Test log not found."
 
       # 9. (Optional) Package Artifacts
       - name: Package AtomSpace
         if: github.ref == 'refs/heads/main'
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make package || echo "Package target not defined."
 
       # 10. (Optional) Upload Test Logs or Packages
@@ -108,11 +108,11 @@ jobs:
         with:
           name: test-logs
           path: |
-            atomspace/build/tests/Testing/Temporary/LastTest.log
+            orch-atomspace/atomspace/build/tests/Testing/Temporary/LastTest.log
 
       - name: Upload Packages
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: atomspace-packages
-          path: atomspace/build/packages/ || echo "No packages to upload."
+          path: orch-atomspace/atomspace/build/packages/ || echo "No packages to upload."

--- a/.github/workflows/ci-org-v7.yml
+++ b/.github/workflows/ci-org-v7.yml
@@ -68,16 +68,16 @@ jobs:
       - name: Build and Install AtomSpace
         run: |
           # Clean existing directory
-          rm -rf atomspace
+          rm -rf orch-atomspace/atomspace
           # Clone the repository
-          git clone https://github.com/opencog/atomspace.git
-          mkdir -p atomspace/build
-          cd atomspace/build
+          git clone https://github.com/opencog/atomspace.git orch-atomspace/atomspace
+          mkdir -p orch-atomspace/atomspace/build
+          cd orch-atomspace/atomspace/build
           cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j2
           sudo make install
           sudo ldconfig
-          cd ../..
+          cd ../../..
 
       # 5. Build and Install CogServer
       - name: Build and Install CogServer
@@ -188,10 +188,10 @@ jobs:
       - name: Run Tests
         run: |
           # AtomSpace Tests
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make tests
           make check ARGS="$MAKEFLAGS"
-          cd ../..
+          cd ../../..
 
           # CogServer Tests
           cd cogserver/build
@@ -242,7 +242,7 @@ jobs:
         with:
           name: test-logs
           path: |
-            atomspace/build/Testing/Temporary/LastTest.log
+            orch-atomspace/atomspace/build/Testing/Temporary/LastTest.log
             cogserver/build/Testing/Temporary/LastTest.log
             opencog/build/Testing/Temporary/LastTest.log
             asmoses/build/Testing/Temporary/LastTest.log
@@ -256,9 +256,9 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           # AtomSpace Packaging
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make package || echo "AtomSpace package target not defined."
-          cd ../..
+          cd ../../..
 
           # Repeat packaging for other components as needed
 
@@ -270,7 +270,7 @@ jobs:
           name: build-artifacts
           path: |
             cogutil/build/
-            atomspace/build/
+            orch-atomspace/atomspace/build/
             cogserver/build/
             opencog/build/
             asmoses/build/

--- a/.github/workflows/ci-org-v8.yml
+++ b/.github/workflows/ci-org-v8.yml
@@ -68,16 +68,16 @@ jobs:
       - name: Build and Install AtomSpace
         run: |
           # Clean existing directory
-          rm -rf atomspace
+          rm -rf orch-atomspace/atomspace
           # Clone the repository
-          git clone https://github.com/opencog/atomspace.git
-          mkdir -p atomspace/build
-          cd atomspace/build
+          git clone https://github.com/opencog/atomspace.git orch-atomspace/atomspace
+          mkdir -p orch-atomspace/atomspace/build
+          cd orch-atomspace/atomspace/build
           cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j2
           sudo make install
           sudo ldconfig
-          cd ../..
+          cd ../../..
 
       # 5. Build and Install CogServer
       - name: Build and Install CogServer
@@ -188,10 +188,10 @@ jobs:
       - name: Run Tests
         run: |
           # AtomSpace Tests
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make tests
           make check ARGS="$MAKEFLAGS"
-          cd ../..
+          cd ../../..
 
           # CogServer Tests
           cd cogserver/build
@@ -242,7 +242,7 @@ jobs:
         with:
           name: test-logs
           path: |
-            atomspace/build/Testing/Temporary/LastTest.log
+            orch-atomspace/atomspace/build/Testing/Temporary/LastTest.log
             cogserver/build/Testing/Temporary/LastTest.log
             opencog/build/Testing/Temporary/LastTest.log
             asmoses/build/Testing/Temporary/LastTest.log
@@ -256,9 +256,9 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           # AtomSpace Packaging
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make package || echo "AtomSpace package target not defined."
-          cd ../..
+          cd ../../..
 
           # Repeat packaging for other components as needed
 
@@ -270,7 +270,7 @@ jobs:
           name: build-artifacts
           path: |
             cogutil/build/
-            atomspace/build/
+            orch-atomspace/atomspace/build/
             cogserver/build/
             opencog/build/
             asmoses/build/

--- a/.github/workflows/ci-org.yml
+++ b/.github/workflows/ci-org.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /ws/ccache
-          key: ccache-atomspace-${{ runner.os }}-${{ hashFiles('atomspace/**') }}
+          key: ccache-atomspace-${{ runner.os }}-${{ hashFiles('orch-atomspace/atomspace/**') }}
           restore-keys: |
             ccache-atomspace-
 
@@ -129,41 +129,41 @@ jobs:
 
       - name: Configure CMake for AtomSpace
         run: |
-          mkdir -p atomspace/build
-          cd atomspace/build
+          mkdir -p orch-atomspace/atomspace/build
+          cd orch-atomspace/atomspace/build
           cmake ..
 
       - name: Build AtomSpace
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make
 
       - name: Install AtomSpace
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           sudo make install
           sudo ldconfig
 
       - name: Build AtomSpace Tests
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make tests
 
       - name: Run AtomSpace Tests
         run: |
-          cd atomspace/build
+          cd orch-atomspace/atomspace/build
           make check ARGS="$MAKEFLAGS"
 
       - name: Print AtomSpace Test Log
         if: always()
         run: |
-          cat atomspace/build/tests/Testing/Temporary/LastTest.log || echo "Test log not found."
+          cat orch-atomspace/atomspace/build/tests/Testing/Temporary/LastTest.log || echo "Test log not found."
 
       - name: Upload AtomSpace Artifact
         uses: actions/upload-artifact@v4
         with:
           name: atomspace
-          path: atomspace/build/
+          path: orch-atomspace/atomspace/build/
 
   cogserver:
     name: CogServer Job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout AtomSpace Repository
         uses: actions/checkout@v4
         with:
-          repository: your-org/atomspace
+          repository: your-org/orch-atomspace/atomspace
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Add build and test steps for AtomSpace here

--- a/.github/workflows/consolidate-atomspace.yml
+++ b/.github/workflows/consolidate-atomspace.yml
@@ -1,0 +1,36 @@
+name: Consolidate AtomSpace Folders
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  consolidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Create orch-atomspace Directory
+        run: mkdir -p orch-atomspace
+
+      - name: Move atomspace Folders to orch-atomspace
+        run: |
+          mv atomspace orch-atomspace/
+          mv atomspace-agents orch-atomspace/
+          mv atomspace-bridge orch-atomspace/
+          mv atomspace-cog orch-atomspace/
+          mv atomspace-dht orch-atomspace/
+          mv atomspace-explorer orch-atomspace/
+          mv atomspace-ipfs orch-atomspace/
+          mv atomspace-js orch-atomspace/
+          mv atomspace-metta orch-atomspace/
+          mv atomspace-restful orch-atomspace/
+          mv atomspace-rocks orch-atomspace/
+          mv atomspace-rpc orch-atomspace/
+          mv atomspace-typescript orch-atomspace/
+          mv atomspace-websockets orch-atomspace/

--- a/.github/workflows/integrate-modules.yml
+++ b/.github/workflows/integrate-modules.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         component: [
-          "agents", "agi-bio", "asmoses", "atomspace-agents", "atomspace-bridge",
-          "atomspace-cog", "atomspace-dht", "atomspace-explorer", "atomspace-ipfs",
-          "atomspace-js", "atomspace-metta", "atomspace-restful", "atomspace-rocks",
-          "atomspace-rpc", "atomspace-typescript", "atomspace-websockets", "atomspace",
+          "agents", "agi-bio", "asmoses", "orch-atomspace/atomspace-agents", "orch-atomspace/atomspace-bridge",
+          "orch-atomspace/atomspace-cog", "orch-atomspace/atomspace-dht", "orch-atomspace/atomspace-explorer", "orch-atomspace/atomspace-ipfs",
+          "orch-atomspace/atomspace-js", "orch-atomspace/atomspace-metta", "orch-atomspace/atomspace-restful", "orch-atomspace/atomspace-rocks",
+          "orch-atomspace/atomspace-rpc", "orch-atomspace/atomspace-typescript", "orch-atomspace/atomspace-websockets", "orch-atomspace/atomspace",
           "attention", "benchmark", "blender_api", "blender_api_msgs", "cheminformatics",
           "cogprotolab", "cogserver", "cogutil", "destin", "dimensional-embedding",
           "distributional-value", "docker", "external-tools", "generate", "ghost_bridge",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake ..
+          cmake ../../orch-atomspace/atomspace
 
       - name: Build and Install
         run: |

--- a/.github/workflows/reusable/atomspace.yml
+++ b/.github/workflows/reusable/atomspace.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
+          cmake ../../orch-atomspace/atomspace
 
       - name: Build
         run: |


### PR DESCRIPTION
Add a new GitHub Action to consolidate all `atomspace` folders under a new `orch-atomspace` folder.

* **New GitHub Action**:
  - Add `.github/workflows/consolidate-atomspace.yml` to automate the consolidation of all `atomspace` folders.
  - Include steps to move all `atomspace` folders to the `orch-atomspace` folder.

* **Update Existing GitHub Actions**:
  - Modify `.github/workflows/ci-org-v2.yml`, `.github/workflows/ci-org-v3.yml`, and `.github/workflows/ci-org-v7.yml` to use the new `orch-atomspace` folder for their respective steps.
  - Update paths and commands to reference the `orch-atomspace` folder instead of individual `atomspace` folders.

* **Devcontainer Configuration**:
  - Modify `.devcontainer/devcontainer.json` to include a new task for building the environment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EchoCog/opencog-central/pull/5?shareId=04316b19-9131-42f0-9b39-0f2c6afa99e3).