### PR TITLE
Fix build directory creation in cogserver workflow

### DIFF
--- a/.github/workflows/cogserver.yml
+++ b/.github/workflows/cogserver.yml
@@ -34,9 +34,11 @@ jobs:
             ccache-cogserver-${{ runner.os }}-
             ccache-cogserver-
 
+      - name: Create Build Directory
+        run: mkdir -p build
+
       - name: Configure Build
         run: |
-          mkdir -p build
           cd build
           cmake ..
 


### PR DESCRIPTION
Add a step to create the `build` directory before using the `cd build` command in the `.github/workflows/cogserver.yml` file.

* Add a new step named "Create Build Directory" to run `mkdir -p build` before the "Configure Build" step.
* Remove the `mkdir -p build` command from the "Configure Build" step as it is now handled separately.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EchoCog/opencog-central/pull/6?shareId=f9fa1c23-9d8b-4d2b-9265-9a5f4d8cebc1).